### PR TITLE
Remove noisy log from db config

### DIFF
--- a/src/config/db.js
+++ b/src/config/db.js
@@ -5,7 +5,10 @@ const dotenv = require('dotenv');
 dotenv.config({ path: require('path').resolve(__dirname, '../../.env') });
 
 
-console.log('Usuario desde .env:', process.env.DB_USER); 
+// Log only in non-production environments for debugging
+if (process.env.NODE_ENV !== 'production') {
+  console.debug('Usuario desde .env:', process.env.DB_USER);
+}
 
 const sequelize = new Sequelize(
   process.env.DB_NAME,


### PR DESCRIPTION
## Summary
- quiet `src/config/db.js` by guarding debug logging with an environment check

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68490588204c83208fc1d981ddcd2b21