### PR TITLE
Enable timestamps on Sequelize models

### DIFF
--- a/src/models/BlogPost.js
+++ b/src/models/BlogPost.js
@@ -1,10 +1,14 @@
 module.exports = (sequelize) => {
   const { DataTypes } = require('sequelize');
 
-  return sequelize.define('BlogPost', {
-    titulo: { type: DataTypes.STRING, allowNull: false },
-    contenido: { type: DataTypes.TEXT, allowNull: false },
-    publicado: { type: DataTypes.BOOLEAN, defaultValue: true },
-    categoriaId: { type: DataTypes.INTEGER, allowNull: false } // FK a Categoria
-  });
+  return sequelize.define(
+    'BlogPost',
+    {
+      titulo: { type: DataTypes.STRING, allowNull: false },
+      contenido: { type: DataTypes.TEXT, allowNull: false },
+      publicado: { type: DataTypes.BOOLEAN, defaultValue: true },
+      categoriaId: { type: DataTypes.INTEGER, allowNull: false } // FK a Categoria
+    },
+    { timestamps: true }
+  );
 };

--- a/src/models/Categoria.js
+++ b/src/models/Categoria.js
@@ -1,8 +1,12 @@
 module.exports = (sequelize) => {
   const { DataTypes } = require('sequelize');
 
-  return sequelize.define('Categoria', {
-    nombre: { type: DataTypes.STRING, allowNull: false },
-    descripcion: { type: DataTypes.TEXT }
-  });
+  return sequelize.define(
+    'Categoria',
+    {
+      nombre: { type: DataTypes.STRING, allowNull: false },
+      descripcion: { type: DataTypes.TEXT }
+    },
+    { timestamps: true }
+  );
 };

--- a/src/models/Comentario.js
+++ b/src/models/Comentario.js
@@ -1,8 +1,12 @@
 module.exports = (sequelize) => {
   const { DataTypes } = require('sequelize');
 
-  return sequelize.define('Comentario', {
-    contenido: { type: DataTypes.TEXT, allowNull: false },
-    postId: { type: DataTypes.INTEGER, allowNull: false } // FK a BlogPost
-  });
+  return sequelize.define(
+    'Comentario',
+    {
+      contenido: { type: DataTypes.TEXT, allowNull: false },
+      postId: { type: DataTypes.INTEGER, allowNull: false } // FK a BlogPost
+    },
+    { timestamps: true }
+  );
 };

--- a/src/models/Empresa.js
+++ b/src/models/Empresa.js
@@ -2,10 +2,14 @@
 const { DataTypes } = require('sequelize');
 
 module.exports = (sequelize) => {
-  return sequelize.define('Empresa', {
-    nombre: { type: DataTypes.STRING, allowNull: false },
-    descripcion: { type: DataTypes.TEXT },
-    rubro: { type: DataTypes.STRING },
-    usuarioId: { type: DataTypes.INTEGER, allowNull: false }, // FK
-  });
+  return sequelize.define(
+    'Empresa',
+    {
+      nombre: { type: DataTypes.STRING, allowNull: false },
+      descripcion: { type: DataTypes.TEXT },
+      rubro: { type: DataTypes.STRING },
+      usuarioId: { type: DataTypes.INTEGER, allowNull: false }, // FK
+    },
+    { timestamps: true }
+  );
 };

--- a/src/models/Oferta.js
+++ b/src/models/Oferta.js
@@ -2,13 +2,17 @@
 const { DataTypes } = require('sequelize');
 
 module.exports = (sequelize) => {
-  return sequelize.define('Oferta', {
-    titulo: { type: DataTypes.STRING, allowNull: false },
-    descripcion: { type: DataTypes.TEXT },
-    requisitos: { type: DataTypes.TEXT },
-    duracion: { type: DataTypes.STRING },
-    requiereCV: { type: DataTypes.BOOLEAN, defaultValue: true },
-    requiereCarta: { type: DataTypes.BOOLEAN, defaultValue: false },
-    empresaId: { type: DataTypes.INTEGER, allowNull: false }, // FK
-  });
+  return sequelize.define(
+    'Oferta',
+    {
+      titulo: { type: DataTypes.STRING, allowNull: false },
+      descripcion: { type: DataTypes.TEXT },
+      requisitos: { type: DataTypes.TEXT },
+      duracion: { type: DataTypes.STRING },
+      requiereCV: { type: DataTypes.BOOLEAN, defaultValue: true },
+      requiereCarta: { type: DataTypes.BOOLEAN, defaultValue: false },
+      empresaId: { type: DataTypes.INTEGER, allowNull: false }, // FK
+    },
+    { timestamps: true }
+  );
 };

--- a/src/models/Postulacion.js
+++ b/src/models/Postulacion.js
@@ -2,13 +2,17 @@
 const { DataTypes } = require('sequelize');
 
 module.exports = (sequelize) => {
-  return sequelize.define('Postulacion', {
-    mensaje: { type: DataTypes.TEXT },
-    estado: {
-      type: DataTypes.ENUM('pendiente', 'aceptada', 'rechazada'),
-      defaultValue: 'pendiente',
+  return sequelize.define(
+    'Postulacion',
+    {
+      mensaje: { type: DataTypes.TEXT },
+      estado: {
+        type: DataTypes.ENUM('pendiente', 'aceptada', 'rechazada'),
+        defaultValue: 'pendiente',
+      },
+      usuarioId: { type: DataTypes.INTEGER, allowNull: false }, // FK
+      ofertaId: { type: DataTypes.INTEGER, allowNull: false },  // FK
     },
-    usuarioId: { type: DataTypes.INTEGER, allowNull: false }, // FK
-    ofertaId: { type: DataTypes.INTEGER, allowNull: false },  // FK
-  });
+    { timestamps: true }
+  );
 };

--- a/src/models/Usuario.js
+++ b/src/models/Usuario.js
@@ -2,17 +2,21 @@
 const { DataTypes } = require('sequelize');
 
 module.exports = (sequelize) => {
-  return sequelize.define('Usuario', {
-    nombre: { type: DataTypes.STRING, allowNull: false },
-    email: { type: DataTypes.STRING, allowNull: false, unique: true },
-    password: { type: DataTypes.STRING, allowNull: false },
-    rol: {
-      type: DataTypes.ENUM('postulante', 'empresa', 'admin'),
-      allowNull: false,
+  return sequelize.define(
+    'Usuario',
+    {
+      nombre: { type: DataTypes.STRING, allowNull: false },
+      email: { type: DataTypes.STRING, allowNull: false, unique: true },
+      password: { type: DataTypes.STRING, allowNull: false },
+      rol: {
+        type: DataTypes.ENUM('postulante', 'empresa', 'admin'),
+        allowNull: false,
+      },
+      cv: {
+        type: DataTypes.STRING, // Puedes guardar la ruta o URL del archivo PDF
+        allowNull: true,        // ✅ Opcional
+      }
     },
-    cv: {
-      type: DataTypes.STRING, // Puedes guardar la ruta o URL del archivo PDF
-      allowNull: true,        // ✅ Opcional
-    }
-  });
+    { timestamps: true }
+  );
 };


### PR DESCRIPTION
## Summary
- add `{ timestamps: true }` option to all model definitions

## Testing
- `npm test` *(fails: Missing script)*
- `NODE_PATH=./node_modules node /tmp/test-sync.js`

------
https://chatgpt.com/codex/tasks/task_e_684a116042408320941c2e1149f2b64e